### PR TITLE
Normalize fade-in-up animation usage

### DIFF
--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -586,7 +586,7 @@ export default function AdminProductsPage() {
                 : "bg-red-100 text-red-800 border border-red-300"
             }`}
             style={{
-              animation: "fadeInUp 0.3s ease-out"
+              animation: "fade-in-up 0.3s ease-out"
             }}
           >
             {status.message}

--- a/src/app/recommendations/page.tsx
+++ b/src/app/recommendations/page.tsx
@@ -287,7 +287,7 @@ function RecommendationsContent() {
                 key={perfume.id}
                 className="h-full min-h-[180px] sm:min-h-[200px]"
                 style={{
-                  animation: `fadeInUp 0.5s ease-out ${index * 0.1}s both`
+                  animation: `fade-in-up 0.5s ease-out ${index * 0.1}s both`
                 }}
               >
                 <MatchCard perfume={perfume} order={index + 1} compact={compact} />


### PR DESCRIPTION
## Summary
- update recommendation cards to reference the shared fade-in-up keyframe animation
- align admin product status message animation with the fade-in-up naming convention

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6705f3b68832093e563ae1ab6718b