### PR TITLE
Ensure Strapi environment variables propagate through Docker workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # ---------- Stage 1: Build ----------
 FROM node:20-alpine AS builder
+ARG NEXT_PUBLIC_STRAPI_URL
+ARG NEXT_PUBLIC_STRAPI_TOKEN
 WORKDIR /app
 
 # Install dependencies
@@ -12,16 +14,22 @@ COPY . .
 # Build environment variables
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_STRAPI_URL=${NEXT_PUBLIC_STRAPI_URL}
+ENV NEXT_PUBLIC_STRAPI_TOKEN=${NEXT_PUBLIC_STRAPI_TOKEN}
 
 # Build the app
 RUN npm run build
 
 # ---------- Stage 2: Runtime ----------
 FROM node:20-alpine AS runner
+ARG NEXT_PUBLIC_STRAPI_URL
+ARG NEXT_PUBLIC_STRAPI_TOKEN
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_PUBLIC_STRAPI_URL=${NEXT_PUBLIC_STRAPI_URL}
+ENV NEXT_PUBLIC_STRAPI_TOKEN=${NEXT_PUBLIC_STRAPI_TOKEN}
 
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,41 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment configuration
+
+The frontend makes authenticated requests to a Strapi backend. Provide the following environment variables whenever you run `npm run build`, `npm start`, or the Docker image so that both the static Next.js bundle and the runtime API calls point to the same backend:
+
+```bash
+NEXT_PUBLIC_STRAPI_URL=<https://your-strapi-host>
+NEXT_PUBLIC_STRAPI_TOKEN=<public-api-token>
+```
+
+For local development you can create a `.env` file in the project root with these keys. The provided `docker-compose.yml` automatically loads `.env` values and passes them to the build so the generated bundle and runtime environment stay aligned.
+
+When building the Docker image manually, pass the values as build arguments and runtime environment variables:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_STRAPI_URL="$NEXT_PUBLIC_STRAPI_URL" \
+  --build-arg NEXT_PUBLIC_STRAPI_TOKEN="$NEXT_PUBLIC_STRAPI_TOKEN" \
+  -t perfume-frontend .
+
+docker run -p 3000:3000 \
+  -e NEXT_PUBLIC_STRAPI_URL="$NEXT_PUBLIC_STRAPI_URL" \
+  -e NEXT_PUBLIC_STRAPI_TOKEN="$NEXT_PUBLIC_STRAPI_TOKEN" \
+  perfume-frontend
+```
+
+## Docker Compose
+
+Create a `.env` file in the project root and set `NEXT_PUBLIC_STRAPI_URL` and `NEXT_PUBLIC_STRAPI_TOKEN` (you can copy from an existing example file if you maintain one). Then run:
+
+```bash
+docker compose up --build
+```
+
+The compose file forwards the same values to both the image build and the running container.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     build:
       context: .
       args:
-        NEXT_PUBLIC_STRAPI_URL: https://kioskapi.gandom-perfume.ir
-        NEXT_PUBLIC_STRAPI_TOKEN: your-public-token-here
+        NEXT_PUBLIC_STRAPI_URL: ${NEXT_PUBLIC_STRAPI_URL}
+        NEXT_PUBLIC_STRAPI_TOKEN: ${NEXT_PUBLIC_STRAPI_TOKEN}
     env_file:
       - .env
+    environment:
+      NEXT_PUBLIC_STRAPI_URL: ${NEXT_PUBLIC_STRAPI_URL}
+      NEXT_PUBLIC_STRAPI_TOKEN: ${NEXT_PUBLIC_STRAPI_TOKEN}
     ports:
       - "3000:3000" # ✅ run on port 80 for production
     restart: always


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_STRAPI_URL and NEXT_PUBLIC_STRAPI_TOKEN args in both Docker stages and set matching ENV values for builds and runtime
- wire docker-compose to source the same values for build args and container environment
- document the required Strapi variables and Docker usage in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6705ed97c8320a2e2c0f0e039e3ca