### PR TITLE
Tighten the kiosk hero presentation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,31 +8,34 @@ export default function HomePage() {
   return (
     <KioskFrame>
       <div className="relative flex h-full w-full items-center justify-center px-4 sm:px-6">
-        <div className="glass-card relative flex w-full max-w-xs flex-col items-center gap-6 xs:max-w-sm sm:max-w-md md:max-w-lg lg:max-w-2xl xl:max-w-3xl sm:gap-8 md:gap-10 lg:gap-12 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-6 sm:p-8 md:p-10 lg:p-12 xl:p-16 text-center">
-          <div className="w-full max-w-[200px] sm:max-w-[280px] md:max-w-[350px] lg:max-w-[450px] transition-transform duration-300 hover:scale-105">
+        <div className="glass-card relative flex w-full max-w-xs flex-col items-center gap-6 rounded-2xl p-6 text-center xs:max-w-sm sm:max-w-md sm:gap-7 sm:rounded-3xl sm:p-8 md:max-w-lg md:gap-8 md:p-10 lg:max-w-2xl lg:gap-10 lg:rounded-[32px] lg:p-12 xl:max-w-3xl xl:gap-12 xl:p-14">
+          <div className="w-full max-w-[200px] transition-transform duration-300 hover:scale-105 sm:max-w-[260px] md:max-w-[340px] lg:max-w-[420px]">
             <Image
               src="/logo.webp"
               alt="لوگوی فروشگاه"
               width={600}
               height={600}
               priority
-              className="w-full h-auto rounded-xl sm:rounded-2xl"
+              className="h-auto w-full rounded-xl sm:rounded-2xl"
             />
           </div>
 
-          <div className="flex flex-col items-center gap-3 sm:gap-4 text-center">
-            <h1 className="m-0 text-xl xs:text-2xl sm:text-3xl md:text-4xl lg:text-[2.9rem] font-semibold leading-tight">
+          <div className="flex flex-col items-center gap-3 sm:gap-4">
+            <span className="inline-flex items-center rounded-full border border-white/60 bg-white/50 px-3 py-1 text-[0.75rem] font-medium text-muted shadow-sm backdrop-blur">
+              کشف رایحه هماهنگ با حال‌وهوایتان
+            </span>
+            <h1 className="m-0 text-xl font-semibold leading-tight xs:text-2xl sm:text-3xl md:text-4xl lg:text-[2.9rem]">
               امضای عطری شما، یک لمس فاصله دارد
             </h1>
-            <p className="m-0 max-w-xl text-xs xs:text-sm sm:text-base text-muted px-2">
-              پرسشنامه را کامل کنید تا مجموعه‌ای از عطرهای منتخب ویژه سلیقه‌تان را ببینید.
+            <p className="m-0 max-w-xl px-2 text-xs text-muted xs:text-sm sm:text-base">
+              پرسشنامه تعاملی را کامل کنید تا در چند دقیقه مجموعه‌ای از عطرهای منتخب و توضیحات کاربردی مخصوص سلیقه‌تان را ببینید.
             </p>
           </div>
 
           <div className="relative">
             <Link
               href="/questionnaire"
-              className="btn tap-highlight touch-target touch-feedback z-10 px-6 py-4 text-base xs:px-7 xs:py-4 sm:px-8 sm:py-5 md:px-10 md:py-6 lg:px-12 sm:text-lg font-medium transition-all duration-300 hover:scale-105 active:scale-95"
+              className="btn tap-highlight touch-target touch-feedback z-10 px-6 py-4 text-base font-medium transition-all duration-300 hover:scale-105 active:scale-95 xs:px-7 xs:py-4 sm:text-lg md:px-10 md:py-6 lg:px-12"
             >
               شروع پرسشنامه
             </Link>
@@ -41,6 +44,10 @@ export default function HomePage() {
               size={180}
             />
           </div>
+
+          <p className="m-0 text-[0.75rem] text-muted sm:text-sm">
+            زمان کم دارید؟ تنها ۳ دقیقه طول می‌کشد و می‌توانید بعداً بازگردید و انتخاب را کامل کنید.
+          </p>
         </div>
       </div>
     </KioskFrame>

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
-import { useRef } from "react";
+import { memo } from "react";
 
 interface GradientCircle {
   id: number;
@@ -24,65 +24,64 @@ interface VeilLayer {
   delay: number;
 }
 
-export default function AnimatedBackground() {
-  const containerRef = useRef<HTMLDivElement>(null);
+const GRADIENT_CIRCLES: GradientCircle[] = [
+  {
+    id: 1,
+    x: 20,
+    y: 26,
+    size: 120,
+    color: "from-white/70 via-white/15 to-transparent",
+  },
+  {
+    id: 2,
+    x: 78,
+    y: 72,
+    size: 95,
+    color: "from-[#eadfcf]/55 via-transparent to-transparent",
+  },
+  {
+    id: 3,
+    x: 54,
+    y: 32,
+    size: 78,
+    color: "from-[#c8b090]/40 via-transparent to-transparent",
+  },
+];
+
+const VEIL_LAYERS: VeilLayer[] = [
+  {
+    id: "veil-1",
+    gradient: "from-white/25 via-white/5 to-transparent",
+    width: 620,
+    height: 420,
+    blur: "blur-[120px]",
+    opacity: 0.25,
+    rotate: -8,
+    translateX: "-30%",
+    translateY: "-45%",
+    delay: 0,
+  },
+  {
+    id: "veil-2",
+    gradient: "from-[#cfae7a]/30 via-transparent to-transparent",
+    width: 540,
+    height: 460,
+    blur: "blur-[140px]",
+    opacity: 0.32,
+    rotate: 12,
+    translateX: "45%",
+    translateY: "55%",
+    delay: 3.2,
+  },
+];
+
+const AnimatedBackground = memo(function AnimatedBackground() {
   const shouldReduceMotion = useReducedMotion();
 
-  const circles: GradientCircle[] = [
-    {
-      id: 1,
-      x: 20,
-      y: 26,
-      size: 120,
-      color: "from-white/70 via-white/15 to-transparent",
-    },
-    {
-      id: 2,
-      x: 78,
-      y: 72,
-      size: 95,
-      color: "from-[#eadfcf]/55 via-transparent to-transparent",
-    },
-    {
-      id: 3,
-      x: 54,
-      y: 32,
-      size: 78,
-      color: "from-[#c8b090]/40 via-transparent to-transparent",
-    },
-  ];
-
-  const veils: VeilLayer[] = [
-    {
-      id: "veil-1",
-      gradient: "from-white/25 via-white/5 to-transparent",
-      width: 620,
-      height: 420,
-      blur: "blur-[120px]",
-      opacity: 0.25,
-      rotate: -8,
-      translateX: "-30%",
-      translateY: "-45%",
-      delay: 0,
-    },
-    {
-      id: "veil-2",
-      gradient: "from-[#cfae7a]/30 via-transparent to-transparent",
-      width: 540,
-      height: 460,
-      blur: "blur-[140px]",
-      opacity: 0.32,
-      rotate: 12,
-      translateX: "45%",
-      translateY: "55%",
-      delay: 3.2,
-    },
-  ];
-
   return (
-    <div ref={containerRef} className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#f9f9f7] via-[#f3f1ec] to-[#ece8e0]" />
-      {circles.map((circle, index) => {
+      {GRADIENT_CIRCLES.map((circle, index) => {
         const baseStyle = {
           width: `${circle.size * 3.6}px`,
           height: `${circle.size * 3.6}px`,
@@ -132,7 +131,7 @@ export default function AnimatedBackground() {
 
       {shouldReduceMotion
         ? null
-        : veils.map((veil) => (
+        : VEIL_LAYERS.map((veil) => (
             <motion.div
               key={veil.id}
               className={`absolute ${veil.blur} bg-gradient-to-br ${veil.gradient} mix-blend-screen`}
@@ -180,4 +179,8 @@ export default function AnimatedBackground() {
       )}
     </div>
   );
-}
+});
+
+AnimatedBackground.displayName = "AnimatedBackground";
+
+export default AnimatedBackground;


### PR DESCRIPTION
## Summary
- restore the lighter kiosk hero layout while preserving the refreshed copy tweaks
- add a subtle tagline chip and completion reassurance without introducing extra sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e673a4bc988320b628c1e91f8b9350