### PR TITLE
Restore kiosk cards with responsive safeguards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,6 +114,7 @@
     direction: rtl;
     scroll-behavior: smooth;
     min-height: 100%;
+    min-height: 100dvh;
     background-color: var(--background);
     overscroll-behavior: none;
     -webkit-user-select: none;
@@ -125,6 +126,8 @@
   body {
     margin: 0;
     min-height: 100vh;
+    min-height: 100svh;
+    min-height: 100dvh;
     background:
       radial-gradient(120% 120% at 85% 0%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0) 60%),
       radial-gradient(140% 140% at 10% 100%, rgba(183, 146, 90, 0.16) 0%, rgba(183, 146, 90, 0) 65%),
@@ -457,6 +460,7 @@
     width: min(100%, 100vw);
     min-height: 100vh;
     min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -469,6 +473,7 @@
     width: min(100%, 100vw);
     max-width: 100%;
     min-height: 100svh;
+    min-height: 100dvh;
     position: relative;
     margin: 0 auto;
     display: flex;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,9 @@ import KioskFrame from "@/components/KioskFrame";
 export default function HomePage() {
   return (
     <KioskFrame>
-      <div className="relative flex h-full w-full items-center justify-center px-4 sm:px-6">
-        <div className="glass-card relative flex w-full max-w-xs flex-col items-center gap-6 rounded-2xl p-6 text-center xs:max-w-sm sm:max-w-md sm:gap-7 sm:rounded-3xl sm:p-8 md:max-w-lg md:gap-8 md:p-10 lg:max-w-2xl lg:gap-10 lg:rounded-[32px] lg:p-12 xl:max-w-3xl xl:gap-12 xl:p-14">
-          <div className="w-full max-w-[200px] transition-transform duration-300 hover:scale-105 sm:max-w-[260px] md:max-w-[340px] lg:max-w-[420px]">
+      <div className="relative flex h-full w-full items-center justify-center px-4 py-6 sm:px-6">
+        <div className="glass-card relative flex w-full max-w-xs flex-col gap-6 rounded-2xl p-6 text-center shadow-soft xs:max-w-sm sm:max-w-md sm:gap-7 sm:rounded-3xl sm:p-8 md:max-w-lg md:gap-8 md:p-10 lg:max-w-2xl lg:gap-10 lg:rounded-[32px] lg:p-12 xl:max-w-3xl xl:gap-12 xl:p-14 max-h-[92vh] overflow-y-auto">
+          <div className="w-full max-w-[200px] self-center transition-transform duration-300 hover:scale-105 sm:max-w-[260px] md:max-w-[340px] lg:max-w-[420px]">
             <Image
               src="/logo.webp"
               alt="لوگوی فروشگاه"
@@ -20,7 +20,7 @@ export default function HomePage() {
             />
           </div>
 
-          <div className="flex flex-col items-center gap-3 sm:gap-4">
+          <div className="flex flex-1 flex-col items-center gap-3 sm:gap-4">
             <span className="inline-flex items-center rounded-full border border-white/60 bg-white/50 px-3 py-1 text-[0.75rem] font-medium text-muted shadow-sm backdrop-blur">
               کشف رایحه هماهنگ با حال‌وهوایتان
             </span>
@@ -32,10 +32,10 @@ export default function HomePage() {
             </p>
           </div>
 
-          <div className="relative">
+          <div className="relative w-full max-w-xs sm:max-w-sm">
             <Link
               href="/questionnaire"
-              className="btn tap-highlight touch-target touch-feedback z-10 px-6 py-4 text-base font-medium transition-all duration-300 hover:scale-105 active:scale-95 xs:px-7 xs:py-4 sm:text-lg md:px-10 md:py-6 lg:px-12"
+              className="btn tap-highlight touch-target touch-feedback z-10 w-full px-6 py-4 text-base font-medium transition-all duration-300 hover:scale-105 active:scale-95 xs:px-7 xs:py-4 sm:text-lg md:px-10 md:py-6 lg:px-12"
             >
               شروع پرسشنامه
             </Link>

--- a/src/app/questionnaire/page.tsx
+++ b/src/app/questionnaire/page.tsx
@@ -191,8 +191,8 @@ export default function Questionnaire() {
 
   return (
     <KioskFrame>
-      <div className="relative flex h-full w-full items-center justify-center px-3 sm:px-4 md:px-6">
-        <div className="glass-card relative flex h-full w-full max-w-full sm:max-w-[95vw] md:max-w-[90vw] lg:max-w-[1200px] flex-col gap-4 sm:gap-5 md:gap-6 rounded-2xl sm:rounded-3xl lg:rounded-[32px] px-4 py-4 sm:px-5 sm:py-5 md:px-6 md:py-6">
+      <div className="relative flex h-full w-full items-center justify-center px-3 py-4 sm:px-4 md:px-6">
+        <div className="glass-card relative flex h-full max-h-[94vh] w-full max-w-full flex-col gap-4 overflow-hidden rounded-2xl px-4 py-4 shadow-soft sm:max-w-[95vw] sm:gap-5 sm:rounded-3xl sm:px-5 sm:py-5 md:max-w-[90vw] md:gap-6 md:px-6 md:py-6 lg:max-w-[1200px] lg:rounded-[32px]">
           <header className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4">
             <div className="space-y-1 sm:space-y-2 text-right flex-1">
               <p className="m-0 text-[10px] xs:text-xs text-muted" aria-live="polite">
@@ -216,8 +216,11 @@ export default function Questionnaire() {
           </header>
 
           <section className="flex flex-1 items-center justify-center overflow-y-auto px-1">
-            <div className="grid w-full max-w-full sm:max-w-[95%] md:max-w-[900px] grid-cols-1 xs:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-2.5 sm:gap-3 md:gap-4 py-2">
-              {currentQuestion.options.map((option, idx) => {
+            <div
+              className="grid w-full max-w-full gap-2.5 py-2 sm:max-w-[95%] sm:gap-3 md:max-w-[900px] md:gap-4"
+              style={{ gridTemplateColumns: "repeat(auto-fit, minmax(min(220px, 100%), 1fr))" }}
+            >
+              {currentQuestion.options.map((option) => {
                 const values = answers[currentQuestion.key];
                 const isSelected = values.includes(option.value);
                 const disabled =

--- a/src/app/recommendations/page.tsx
+++ b/src/app/recommendations/page.tsx
@@ -207,12 +207,16 @@ function RecommendationsContent() {
 
   if (loading) {
     return (
-      <div className="flex h-full w-full items-center justify-center px-2 sm:px-3 md:px-4 lg:px-6 xl:px-8">
-        <div className="glass-card relative flex h-[95vh] sm:h-[92vh] w-full max-w-full sm:max-w-[98vw] md:max-w-[95vw] lg:max-w-[90vw] xl:max-w-[1400px] flex-col gap-3 sm:gap-4 md:gap-5 lg:gap-6 rounded-2xl sm:rounded-3xl lg:rounded-[32px] px-3 py-3 sm:px-4 sm:py-4 md:px-5 md:py-5 lg:px-6 lg:py-6">
+      <div className="flex h-full w-full items-center justify-center px-2 py-4 sm:px-3 md:px-4 lg:px-6 xl:px-8">
+        <div className="glass-card relative flex h-full max-h-[94vh] w-full max-w-6xl flex-col gap-3 overflow-hidden rounded-2xl px-3 py-3 shadow-soft sm:gap-4 sm:rounded-3xl sm:px-4 sm:py-4 md:gap-5 md:px-5 md:py-5 lg:gap-6 lg:px-6 lg:py-6">
           <header className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 sm:gap-3">
             <h1 className="text-xl xs:text-2xl sm:text-2xl md:text-3xl font-semibold text-[var(--color-foreground)]">در حال بارگذاری...</h1>
           </header>
-          <section className="grid flex-1 grid-cols-2 grid-rows-3 sm:grid-cols-3 sm:grid-rows-2 auto-rows-fr gap-2 sm:gap-2.5 md:gap-3 lg:gap-3 xl:gap-4 overflow-y-auto">
+          <section className="flex-1 overflow-hidden">
+            <div
+              className="grid h-full w-full gap-2 overflow-y-auto pr-1 sm:gap-2.5 md:gap-3 lg:gap-3 xl:gap-4"
+              style={{ gridTemplateColumns: "repeat(auto-fit, minmax(min(220px, 100%), 1fr))" }}
+            >
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="h-full min-h-[180px] sm:min-h-[200px]">
                 <div className="glass-card flex h-full flex-col gap-3 sm:gap-4 md:gap-5 rounded-2xl sm:rounded-3xl p-3 sm:p-4 md:p-5 lg:p-6 animate-pulse">
@@ -231,6 +235,7 @@ function RecommendationsContent() {
                 </div>
               </div>
             ))}
+            </div>
           </section>
         </div>
       </div>
@@ -269,8 +274,8 @@ function RecommendationsContent() {
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-center px-2 sm:px-3 md:px-4 lg:px-6 xl:px-8">
-      <div className="glass-card relative flex h-[95vh] sm:h-[92vh] w-full max-w-full sm:max-w-[98vw] md:max-w-[95vw] lg:max-w-[90vw] xl:max-w-[1400px] flex-col gap-3 sm:gap-4 md:gap-5 lg:gap-6 rounded-2xl sm:rounded-3xl lg:rounded-[32px] px-3 py-3 sm:px-4 sm:py-4 md:px-5 md:py-5 lg:px-6 lg:py-6">
+    <div className="flex h-full w-full items-center justify-center px-2 py-4 sm:px-3 md:px-4 lg:px-6 xl:px-8">
+      <div className="glass-card relative flex h-full max-h-[94vh] w-full max-w-6xl flex-col gap-3 overflow-hidden rounded-2xl px-3 py-3 shadow-soft sm:gap-4 sm:rounded-3xl sm:px-4 sm:py-4 md:gap-5 md:px-5 md:py-5 lg:gap-6 lg:px-6 lg:py-6">
         <header className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 sm:gap-3">
           <h1 className="text-xl xs:text-2xl sm:text-2xl md:text-3xl font-semibold text-[var(--color-foreground)]">پیشنهادهای شما</h1>
           {recommendations.length > 0 && (
@@ -280,7 +285,11 @@ function RecommendationsContent() {
           )}
         </header>
 
-        <section className="grid flex-1 grid-cols-2 grid-rows-3 sm:grid-cols-3 sm:grid-rows-2 auto-rows-fr gap-2 sm:gap-2.5 md:gap-3 lg:gap-3 xl:gap-4 overflow-y-auto">
+        <section className="flex-1 overflow-hidden">
+          <div
+            className="grid h-full w-full gap-2 overflow-y-auto pr-1 sm:gap-2.5 md:gap-3 lg:gap-3 xl:gap-4"
+            style={{ gridTemplateColumns: "repeat(auto-fit, minmax(min(220px, 100%), 1fr))" }}
+          >
           {recommendations.length > 0 ? (
             recommendations.map((perfume, index) => (
               <div
@@ -301,6 +310,7 @@ function RecommendationsContent() {
               </Link>
             </div>
           )}
+          </div>
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restore the centered hero card layout while adding safe-area padding and scroll fallbacks for short displays
- tighten questionnaire and recommendation shells with auto-fit option grids and capped heights to prevent overflow
- ensure kiosk frames respect dynamic viewport heights for mobile browsers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68c60413c8320a810bc3da088267b