### PR TITLE
Add reusable start questionnaire button to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Image from "next/image";
-import Link from "next/link";
-import TapIndicator from "@/components/TapIndicator";
+import StartQuestionnaireButton from "@/components/StartQuestionnaireButton";
 import KioskFrame from "@/components/KioskFrame";
 
 export default function HomePage() {
@@ -32,18 +31,7 @@ export default function HomePage() {
             </p>
           </div>
 
-          <div className="relative w-full max-w-xs sm:max-w-sm">
-            <Link
-              href="/questionnaire"
-              className="btn tap-highlight touch-target touch-feedback z-10 w-full px-6 py-4 text-base font-medium transition-all duration-300 hover:scale-105 active:scale-95 xs:px-7 xs:py-4 sm:text-lg md:px-10 md:py-6 lg:px-12"
-            >
-              شروع پرسشنامه
-            </Link>
-            <TapIndicator
-              className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-              size={180}
-            />
-          </div>
+          <StartQuestionnaireButton />
 
           <p className="m-0 text-[0.75rem] text-muted sm:text-sm">
             زمان کم دارید؟ تنها ۳ دقیقه طول می‌کشد و می‌توانید بعداً بازگردید و انتخاب را کامل کنید.

--- a/src/components/StartQuestionnaireButton.tsx
+++ b/src/components/StartQuestionnaireButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import TapIndicator from "@/components/TapIndicator";
+
+interface StartQuestionnaireButtonProps {
+  className?: string;
+}
+
+export default function StartQuestionnaireButton({
+  className = "",
+}: StartQuestionnaireButtonProps) {
+  return (
+    <div className={`relative w-full max-w-xs sm:max-w-sm ${className}`}>
+      <Link
+        href="/questionnaire"
+        prefetch={false}
+        className="btn tap-highlight touch-target touch-feedback z-10 w-full px-6 py-4 text-base font-medium transition-all duration-300 hover:scale-105 active:scale-95 xs:px-7 xs:py-4 sm:text-lg md:px-10 md:py-6 lg:px-12"
+        aria-label="شروع پرسشنامه و رفتن به فرم انتخاب عطر"
+      >
+        شروع پرسشنامه
+      </Link>
+      <TapIndicator
+        className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        size={180}
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated StartQuestionnaireButton component that renders the questionnaire CTA with its tap indicator
- reuse the component on the home page so visitors see a clear way to launch the questionnaire

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6929a6b288320b4196a482955b2c8